### PR TITLE
:globe_with_meridians: Add a British English (en_gb) dictionary (iTop 3.3)

### DIFF
--- a/dictionaries/en_gb.dict.combodo-oauth2-client.php
+++ b/dictionaries/en_gb.dict.combodo-oauth2-client.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * @copyright   Copyright (C) 2010-2026 Combodo SARL
+ * @license     http://opensource.org/licenses/AGPL-3.0
+ */
+
+/**
+ * Localized data
+ *
+ * Only the entries whose spelling differs from EN US are listed here; every
+ * other string falls back to the EN US dictionary.
+ */
+
+Dict::Add('EN GB', 'British English', 'British English', [
+	'Class:Oauth2Client/Attribute:authorization_state' => 'Authorisation State',
+]);


### PR DESCRIPTION
The module ships no `en_gb` dictionary, so British users fall back to EN US
throughout, including for the entries whose British spelling differs.

This pull request adds one holding only those entries.

Dictionary keys and the EN US entries are untouched. Where an `en_gb` entry is
absent, `Dict` already falls back to EN US, so nothing is duplicated for the
sake of it.